### PR TITLE
Allow for attachment post meta to be exposed via post type mapping.

### DIFF
--- a/wp-graphql-meta.php
+++ b/wp-graphql-meta.php
@@ -22,8 +22,15 @@ add_action( 'graphql_init', function() {
 		array( 'user' )
 	);
 
+	// Some WPGraphQL type names differ from their post types.
+	$mapping = array(
+		'attachment' => 'mediaItem',
+	);
+
 	foreach ( $all_types as $type ) {
-		add_filter( "graphql_{$type}_fields", function ( $fields ) use ( $type ) {
+		$graphql_type = isset( $mapping[ $type ] ) ? $mapping[ $type ] : $type;
+
+		add_filter( "graphql_{$graphql_type}_fields", function ( $fields ) use ( $type ) {
 			return add_meta_fields( $fields, $type );
 		} );
 	}


### PR DESCRIPTION
WPGraphQL uses `mediaItem` as the type name for attachments, which means that meta registered against the `attachment` post type isn't respected. This adds a mapping array so that post types can be mapped to GraphQL types.